### PR TITLE
Fix entity id type and CrossOrigin annotation

### DIFF
--- a/src/main/java/com/example/chatapp/User.java
+++ b/src/main/java/com/example/chatapp/User.java
@@ -11,7 +11,8 @@ public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "UserID", nullable = false, unique = true)
-    private int id;
+    // Use Integer to allow null before the entity is persisted
+    private Integer id;
 
     @Column(name = "Name", nullable = false)
     private String name;

--- a/src/main/java/com/example/chatapp/controller/UserController.java
+++ b/src/main/java/com/example/chatapp/controller/UserController.java
@@ -10,7 +10,8 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api")
-@CrossOrigin(origins = "http://localhost:3000", allowCredentials = "true")
+// allowCredentials expects a boolean value
+@CrossOrigin(origins = "http://localhost:3000", allowCredentials = true)
 public class UserController {
 
     @Autowired


### PR DESCRIPTION
## Summary
- use `Integer` for `User.id` so JPA can handle null values
- correct `@CrossOrigin` configuration in `UserController`

## Testing
- `mvn -q -DskipTests=false package` *(fails: `mvn` not found)*
- `npm test --prefix chat-frontend --silent` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af0d7fe008320ade7c353fb25e2bd