### PR TITLE
Fix chat list fetch url and auth

### DIFF
--- a/chat-frontend/src/components/ChatList.jsx
+++ b/chat-frontend/src/components/ChatList.jsx
@@ -6,14 +6,16 @@ const ChatList = ({ onSelectChat, activeChatId }) => {
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
-        fetch('/api/conversations', {
-            credentials: 'include',
+        const token = localStorage.getItem('token');
+        fetch('http://localhost:8080/api/conversations', {
+            headers: { Authorization: `Bearer ${token}` }
         })
             .then(res => res.json())
             .then(data => {
                 setConversations(data);
                 setLoading(false);
-            });
+            })
+            .catch(() => setLoading(false));
     }, []);
 
     if (loading) return <div className="chat-list">Lädt...</div>;
@@ -25,10 +27,13 @@ const ChatList = ({ onSelectChat, activeChatId }) => {
                 <div
                     key={conv.partnerId}
                     className={`chat-list-item${activeChatId === conv.partnerId ? ' active' : ''}`}
-                    onClick={() => onSelectChat(conv.partnerId)}
+                    onClick={() => onSelectChat(conv)}
                 >
                     <div className="chat-list-name">{conv.partnerName}</div>
-                    <div className="chat-list-last">{conv.lastMessage}</div>
+                    <div className="chat-list-last">
+                        {conv.lastSentByMe ? 'Du: ' : `${conv.partnerName}: `}
+                        {conv.lastMessage}
+                    </div>
                     <div className="chat-list-time">{new Date(conv.timestamp).toLocaleString()}</div>
                 </div>
             ))}
@@ -36,4 +41,4 @@ const ChatList = ({ onSelectChat, activeChatId }) => {
     );
 };
 
-export default ChatList; 
+export default ChatList;

--- a/chat-frontend/src/components/PrivateChat.jsx
+++ b/chat-frontend/src/components/PrivateChat.jsx
@@ -12,6 +12,11 @@ function PrivateChat({ username }) {
     const [partner, setPartner] = useState(null);
     const [activeChatId, setActiveChatId] = useState(null);
 
+    const handleSelectChat = (conv) => {
+        setPartner({ id: conv.partnerId, name: conv.partnerName });
+        setActiveChatId(conv.partnerId);
+    };
+
     useEffect(() => {
         const token = localStorage.getItem('token');
         const socket = new SockJS(`http://localhost:8080/ws?token=${token}`);
@@ -54,7 +59,7 @@ function PrivateChat({ username }) {
                 } catch {}
             })();
         }
-    }, [activeChatId]);
+    }, [activeChatId, partner]);
 
     const searchUser = async () => {
         try {
@@ -65,6 +70,7 @@ function PrivateChat({ username }) {
             if (!res.ok) throw new Error('Benutzer nicht gefunden');
             const data = await res.json();
             setPartner(data);
+            setActiveChatId(data.id);
             const histRes = await fetch(`http://localhost:8080/api/messages/${data.id}`, {
                 headers: { Authorization: `Bearer ${token}` }
             });
@@ -107,7 +113,7 @@ function PrivateChat({ username }) {
 
     return (
         <div className="chat-wrapper">
-            <ChatList onSelectChat={setActiveChatId} activeChatId={activeChatId} />
+            <ChatList onSelectChat={handleSelectChat} activeChatId={activeChatId} />
             <div className="chat-container">
                 <div className="search-container" style={{ boxShadow: '0 2px 8px rgba(44,62,80,0.06)', background: '#fff', borderRadius: 'var(--border-radius)', marginBottom: 0 }}>
                     <span style={{ color: 'var(--primary-color)', fontSize: 20, marginRight: 8 }}><FaSearch /></span>

--- a/src/main/java/com/example/chatapp/config/WebSocketConfig.java
+++ b/src/main/java/com/example/chatapp/config/WebSocketConfig.java
@@ -2,13 +2,19 @@ package com.example.chatapp.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.web.socket.config.annotation.*;
 import com.example.chatapp.security.JwtHandshakeInterceptor;
 import com.example.chatapp.security.CustomHandshakeHandler;
+import com.example.chatapp.security.StompAuthInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Autowired
+    private StompAuthInterceptor stompAuthInterceptor;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -24,5 +30,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         config.enableSimpleBroker("/topic", "/queue");
         config.setApplicationDestinationPrefixes("/app");
         config.setUserDestinationPrefix("/user");
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompAuthInterceptor);
     }
 }

--- a/src/main/java/com/example/chatapp/controller/UserController.java
+++ b/src/main/java/com/example/chatapp/controller/UserController.java
@@ -93,7 +93,8 @@ public class UserController {
             Integer partnerId = msg.getSenderId().equals(current.getId()) ? msg.getReceiverId() : msg.getSenderId();
             User partner = userRepository.findById(partnerId).orElse(null);
             String partnerName = partner != null ? partner.getName() : "Unbekannt";
-            return new ChatOverviewDTO(partnerId, partnerName, msg.getContent(), msg.getTimestamp());
+            boolean lastSentByMe = msg.getSenderId().equals(current.getId());
+            return new ChatOverviewDTO(partnerId, partnerName, msg.getContent(), msg.getTimestamp(), lastSentByMe);
         }).toList();
         return ResponseEntity.ok(overview);
     }

--- a/src/main/java/com/example/chatapp/model/ChatOverviewDTO.java
+++ b/src/main/java/com/example/chatapp/model/ChatOverviewDTO.java
@@ -12,4 +12,5 @@ public class ChatOverviewDTO {
     private String partnerName;
     private String lastMessage;
     private LocalDateTime timestamp;
-} 
+    private boolean lastSentByMe;
+}


### PR DESCRIPTION
## Summary
- connect ChatList to the backend using the correct URL
- attach the JWT token when fetching conversations
- show who sent the last message in ChatList
- selecting a chat now loads history and sets the partner
- secure WebSocket messages using `StompAuthInterceptor`

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*
- `npm test --silent` *(fails: `react-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68666b6a043c832080d0bd19d3acec2c